### PR TITLE
Fix: Amazon error for GetLowestOfferListingsForASIN

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ exports = module.exports = function(options) {
 
     var skuList       = (options && options.skuList)            ? options.skuList       : null,
         itemCondition = (options && options.itemCondition)      ? options.itemCondition : 'Any',
-        excludeMe     = (options && options.excludeMe === true) ? 'True'                : 'False';
+        excludeMe     = (options && options.excludeMe === true) ? 'true'                : 'false';
 
     // Request
     var reqForm = {query: {"Action": "GetLowestOfferListingsForSKU", "MarketplaceId": mpList[mpCur].id, "ItemCondition": itemCondition, "ExcludeMe": excludeMe}};
@@ -320,7 +320,7 @@ exports = module.exports = function(options) {
 
     var asinList      = (options && options.asinList)           ? options.asinList      : null,
         itemCondition = (options && options.itemCondition)      ? options.itemCondition : 'Any',
-        excludeMe     = (options && options.excludeMe === true) ? 'True'                : 'False';
+        excludeMe     = (options && options.excludeMe === true) ? 'true'                : 'false';
 
     // Request
     var reqForm = {query: {"Action": "GetLowestOfferListingsForASIN", "MarketplaceId": mpList[mpCur].id, "ItemCondition": itemCondition, "ExcludeMe": excludeMe}};


### PR DESCRIPTION
I was getting the below error whenever I was using 'GetLowestOfferListingsForASIN'.

'Response error! (boolean must follow xsd1.1 definition(Sender/MalformedInput))'

Changing the booleans being passed in fixed this problem.